### PR TITLE
3주차 PR - 동민

### DIFF
--- a/dongmin/programmers/level1/PG42840.java
+++ b/dongmin/programmers/level1/PG42840.java
@@ -1,0 +1,48 @@
+package algoitzy.week3;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+// 모의고사
+public class PG42840 {
+    static int[][] pattern = {
+            {1, 2, 3, 4, 5}, // 5
+            {2, 1, 2, 3, 2, 4, 2, 5}, // 8
+            {3, 3, 1, 1, 2, 2, 4, 4, 5, 5} // 10
+    };
+
+    public static void main(String[] args) {
+        int[] solution = solution(new int[]{1, 3, 2, 4, 2});
+        System.out.println(Arrays.toString(solution));
+    }
+
+    public static int[] solution(int[] answers) {
+        int[] MathGiveUp = new int[3];
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < answers.length; j++) {
+                int index = j % pattern[i].length;
+                if (answers[j] == pattern[i][index]) {
+                    MathGiveUp[i]++;
+                }
+            }
+        }
+
+        int max = Math.max(MathGiveUp[0], Math.max(MathGiveUp[1], MathGiveUp[2]));
+
+        List<Integer> list = new ArrayList<>();
+        for (int i = 0; i < MathGiveUp.length; i++) {
+            if(MathGiveUp[i] == max) {
+                list.add(i + 1);
+            }
+        }
+
+        int[] rank = new int[list.size()];
+        for (int i = 0; i < rank.length; i++) {
+            rank[i] = list.get(i);
+        }
+
+        return rank;
+        // return list.stream().mapToInt(x -> x).toArray(); 스트림 시간 진짜 오래 걸림... 2초대..
+    }
+}

--- a/dongmin/programmers/level1/PG86491.java
+++ b/dongmin/programmers/level1/PG86491.java
@@ -1,0 +1,23 @@
+package algoitzy.week3;
+
+// 최소직사각형 [완전탐색]
+public class PG86491 {
+    public static void main(String[] args) {
+        int solution = solution(new int[][]{{60, 50}, {30, 70}, {60, 30}, {80, 40}});
+        System.out.println("solution = " + solution);
+    }
+
+    public static int solution(int[][] sizes) {
+
+        int width = 0;
+        int height = 0;
+
+        for (int[] size : sizes) {
+            width = Math.max(width, Math.max(size[0], size[1]));
+            height = Math.max(height, Math.min(size[0], size[1]));
+        }
+
+        return width * height;
+
+    }
+}

--- a/dongmin/programmers/level2/PG42586.java
+++ b/dongmin/programmers/level2/PG42586.java
@@ -1,0 +1,55 @@
+package algoitzy.week3;
+
+import java.util.*;
+
+// 기능개발 [스택/큐]
+public class PG42586 {
+    public static void main(String[] args) {
+        int[] solution = solution(new int[]{95, 90, 99, 99, 80, 99}, new int[]{1, 1, 1, 1, 1, 1});
+        System.out.println(Arrays.toString(solution));
+    }
+
+    public static int[] solution(int[] progresses, int[] speeds) {
+
+        Queue<Integer> queue = new LinkedList<>();
+        for (int progress : progresses) {
+            queue.offer(progress);
+        }
+
+        Queue<Integer> dayQueue = new LinkedList<>();
+        for (int speed : speeds) {
+            int day = 0;
+            int q = queue.poll();
+            while (q < 100) {
+                q += speed;
+                day++;
+            }
+            dayQueue.offer(day);
+        }
+
+        List<Integer> list = new ArrayList<>();
+        int func = dayQueue.poll();
+        int count = 1;
+        while (!dayQueue.isEmpty()) {
+            if (func >= dayQueue.peek()) { // 개발 기간이 같은 기능은 같은 날 배포가 되어야함!
+                dayQueue.poll();
+                count++;
+            } else {
+                list.add(count);
+                func = dayQueue.poll();
+                count = 1;
+            }
+
+            if(dayQueue.size() == 0) {
+                list.add(count);
+            }
+        }
+
+        int[] result = new int[list.size()];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = list.get(i);
+        }
+
+        return result;
+    }
+}

--- a/dongmin/programmers/level2/PG42587.java
+++ b/dongmin/programmers/level2/PG42587.java
@@ -1,0 +1,37 @@
+package algoitzy.week3;
+
+import java.util.*;
+
+// 프린터
+public class PG42587 {
+    public static void main(String[] args) {
+        int solution = solution(new int[]{1, 1, 9, 1, 1, 1}, 0);
+        System.out.println("solution = " + solution);
+    }
+
+    public static int solution(int[] priorities, int location) {
+
+        Queue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
+        for (int priority : priorities) {
+            pq.add(priority);
+        }
+
+        int count = 0;
+
+        loop:
+        while (!pq.isEmpty()) {
+            for (int i = 0; i < priorities.length; i++) {
+                if (priorities[i] == pq.peek()) {
+                    if (location == i) {
+                        count++;
+                        break loop;
+                    }
+                    pq.poll();
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
#### `모의고사`
> 완전탐색
- 학생이 문제를 찍는 패턴을 배열에 저장하고, 각 학생별 정답의 개수를 저장할 배열을 선언
- 문제 배열을 반복하면서, 문제 배열의 값과 패턴 배열의 값이 같은 경우 해당 학생의 정답의 개수 + 1 → `MathGiveUp[i]++`
- 정답 개수 배열에서 최대값을 구하고, 정답 개수 배열을 돌면서 최대값과 같은 값을 가진 학생을 list에 저장
- list를 순서대로 배열에 담아서 반환

#### `최소직사각형`
> 완전탐색
- 명함 배열을 돌면서 큰 값들은 가로, 작은 값들은 세로에 저장
- 가로의 최대값 x 세로의 최대값을 반환

#### `기능개발`
> 스택 / 큐
- 큐에 작업 배열의 값들을 넣고, 해당 작업별 개발 속도를 구해서 다시 큐에 저장
- 앞의 기능의 개발속도가 현재 기능의 개발속도보다 느린 경우에는 함께 배포가 되어야하기 때문에 count + 1
- 반대의 경우에는 count를 저장하고 count를 1로 초기화 후에 다시 비교 시작

#### `프린터`
> 스택 / 큐
- 우선순위 큐를 사용해서 풀이
- 문서를 출력할 때 `queue.poll`로 해당 문서를 제거하고 count + 1
- 현재 문서의 중요도와 큐의 최신 문서의 중요도가 같고, 현재 문서의 인덱스와 location이 같은 경우에 count를 반환