### PR TITLE
16주차 PR - 동민

### DIFF
--- a/dongmin/baekjoon/dp/silver/3/BOJ1003.java
+++ b/dongmin/baekjoon/dp/silver/3/BOJ1003.java
@@ -1,0 +1,33 @@
+package algoitzy.week16;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+// 피보나치 함수
+public class BOJ1003 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int t = Integer.parseInt(br.readLine());
+
+        int[][] dp = new int[41][2]; // n번째 피보나치를 호출했을 때 나오는 0, 1의 개수
+        dp[0][0] = 1;
+        dp[0][1] = 0;
+        dp[1][0] = 0;
+        dp[1][1] = 1;
+
+        for (int i = 2; i < 41; i++) {
+            dp[i][0] = dp[i - 1][0] + dp[i - 2][0];
+            dp[i][1] = dp[i - 1][1] + dp[i - 2][1];
+        }
+
+        for (int i = 0; i < t; i++) {
+            StringBuilder sb = new StringBuilder();
+            int n = Integer.parseInt(br.readLine());
+
+            sb.append(dp[n][0]).append(" ").append(dp[n][1]);
+            System.out.println(sb);
+        }
+    }
+}

--- a/dongmin/baekjoon/dp/silver/3/BOJ11726.java
+++ b/dongmin/baekjoon/dp/silver/3/BOJ11726.java
@@ -1,0 +1,23 @@
+package algoitzy.week16;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+// 2×n 타일링
+public class BOJ11726 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        long[] dp = new long[1001];
+        dp[1] = 1;
+        dp[2] = 2;
+
+        for (int i = 3; i < 1001; i++) {
+            dp[i] = (dp[i - 1] + dp[i - 2]) % 10007; // 여기서 나눠서 넣어줘야 오버플로우 방지 가능
+        }
+
+        System.out.println(dp[n]);
+    }
+}

--- a/dongmin/baekjoon/dp/silver/3/BOJ1463.java
+++ b/dongmin/baekjoon/dp/silver/3/BOJ1463.java
@@ -1,0 +1,30 @@
+package algoitzy.week16;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ1463 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[] dp = new int[n + 1];
+        dp[0] = -1;
+
+        // 각 숫자별 최소 연산의 횟수를 저장한다..?
+        for (int i = 1; i <= n; i++) {
+            if (i % 3 == 0 && i % 2 == 0) {
+                dp[i] = Math.min(dp[i / 3] + 1, dp[i / 2] + 1);
+            } else if (i % 3 == 0) {
+                dp[i] = Math.min(dp[i / 3] + 1, dp[i - 1] + 1);
+            } else if(i % 2 == 0){
+                dp[i] = Math.min(dp[i / 2] + 1, dp[i - 1] + 1);
+            } else {
+                dp[i] = dp[i - 1] + 1;
+            }
+        }
+
+        System.out.println(dp[n]);
+    }
+}

--- a/dongmin/baekjoon/dp/silver/3/BOJ1463.java
+++ b/dongmin/baekjoon/dp/silver/3/BOJ1463.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
+// 1로 더하기
 public class BOJ1463 {
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

--- a/dongmin/baekjoon/dp/silver/3/BOJ9095.java
+++ b/dongmin/baekjoon/dp/silver/3/BOJ9095.java
@@ -1,0 +1,28 @@
+package algoitzy.week16;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+// 1로 만들기
+public class BOJ9095 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int t = Integer.parseInt(br.readLine());
+
+        int[] dp = new int[11];
+
+        dp[1] = 1;
+        dp[2] = 2;
+        dp[3] = 4;
+
+        for (int i = 4; i < 11; i++) {
+            dp[i] = dp[i - 3] + dp[i - 2] + dp[i - 1];
+        }
+
+        for (int i = 0; i < t; i++) {
+            int n = Integer.parseInt(br.readLine());
+            System.out.println(dp[n]);
+        }
+    }
+}

--- a/dongmin/baekjoon/dp/silver/3/BOJ9095.java
+++ b/dongmin/baekjoon/dp/silver/3/BOJ9095.java
@@ -4,7 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-// 1로 만들기
+// 1, 2, 3 더하기
 public class BOJ9095 {
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));


### PR DESCRIPTION
## 1로 만들기
- 1~n까지의 각 숫자별 최소 연산의 횟수를 배열에 저장한다.
- 숫자가 3으로 나누어 떨어지는 경우 `dp[i / 3] + 1`과 `dp[i - 1] + 1`을 비교해서 더 작은 값을 저장한다.
- 숫자가 2로 나누어 떨어지는 경우 `dp[i / 2] + 1`과 `dp[i - 1] + 1`을 비교해서 더 작은 값을 저장한다.
- 숫자가 2와 3으로 둘 다 나누어 떨어지는 경우 `dp[i / 2] + 1`과 `dp[i / 3] + 1`을 비교해서 더 작은 값을 저장한다.
- 나머지 경우에는 `dp[i - 1] + 1`을 배열에 저장한다.

## 1, 2, 3 더하기
- 점화식 `dp[i] = dp[i - 3] + dp[i - 2] + dp[i - 1]`
- n에서 각 배열 인덱스 숫자를 뺀 값을 식에 더하면 n을 만들 수 있다.
- 해당 숫자에 숫자만 추가되기 떄문에 개수에는 변동이 없고, 개수를 그대로 더히면 식의 개수를 구할 수 있다.

## 피보나치 함수
- 2차원 배열에 피보나치 함수의 결과로 나오는 0, 1의 개수를 저장한다.
- 0의 개수를 구하는 점화식 `dp[i][0] = dp[i - 1][0] + dp[i - 2][0]`
- 1의 개수를 구하는 점화식 `dp[i][1] = dp[i - 1][1] + dp[i - 2] [1]`

## 2×n 타일링
- 반복을 진행하다보면 `n - 1` 타일과 `n - 2` 타일을 이용해서 n번째 타일 패턴을 만들 수 있다는 걸 확인할 수 있다.
- 반복을 하면서 10007로 나눈 값을 배열에 담는다. 
- `출력 후 나누는 경우에는 오버 플로우로 들어간 값을 나누기 때문에 정확한 값이 나오지 않는다.`
- 점화식 `dp[n] = dp[n - 1] + dp[n - 2]`